### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ Swift version of [CPAnimationSequence](https://github.com/yangmeyer/CPAnimationS
 # CPAnimationSequenceSwift
 
 ## Installation
-* If you don't use Cocoapods, you can drag and drop the files from **SwiftAnimation** folder into your project and use it.
+* If you don't use CocoaPods, you can drag and drop the files from **SwiftAnimation** folder into your project and use it.
 
-* If you use Cocoapods, you can see below on how to add CPAnimationSequenceSwift into podfile.
+* If you use CocoaPods, you can see below on how to add CPAnimationSequenceSwift into podfile.
 
 ### Podfile
 
@@ -15,7 +15,7 @@ Swift version of [CPAnimationSequence](https://github.com/yangmeyer/CPAnimationS
 	
 		pod 'CPAnimationSequenceSwift', '0.0.1' 
 
-* If you want to add support from `iOS 7`, you can drag and drop source files into your project and use it. `Cocoapods` for swift supports from `iOS 8` only because of dynamic frameworks.
+* If you want to add support from `iOS 7`, you can drag and drop source files into your project and use it. `CocoaPods` for swift supports from `iOS 8` only because of dynamic frameworks.
 
 
 ### Usage


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
